### PR TITLE
Added configurable setupapp ident string

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The entire API is bundled in a [Docker Image](https://hub.docker.com/r/kimbtechn
 			JSON like `{ "key" : { name : "Test 1" }, ... }`
       	- `CONF_OWN_STREAM_URL` URL where each audiofile can be accessed, the `key` will be appended
       	- `CONF_PROXY_OWN_STREAM` Use the builtin HTTP proxy for own streams `true/ false`.
+      	- `CONF_SETUPAPP_IDENT` Sets the setupapp ident string (seems to vary per manufactuer. Example: When the setupapp URI is `/setupapp/hama/asp/BrowseXML/loginXML.asp` you have to set `hama` here).
 	- There are to ways to store, which episodes of a podcasts were already played (new ones are marked by `*`)
 		- Use the Redis-Data-Volume (Redis will load its dump files on container startup)
 		- Create a CronJob to `/cron.php` (this will dump the already played episodes to a JSON-File and load the file on container startup)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The entire API is bundled in a [Docker Image](https://hub.docker.com/r/kimbtechn
 			JSON like `{ "key" : { name : "Test 1" }, ... }`
       	- `CONF_OWN_STREAM_URL` URL where each audiofile can be accessed, the `key` will be appended
       	- `CONF_PROXY_OWN_STREAM` Use the builtin HTTP proxy for own streams `true/ false`.
-      	- `CONF_SETUPAPP_IDENT` Sets the setupapp ident string (seems to vary per manufactuer. Example: When the setupapp URI is `/setupapp/hama/asp/BrowseXML/loginXML.asp` you have to set `hama` here).
+      	- `CONF_SETUPAPP_IDENT` Sets the setupapp ident string (seems to vary per manufacturer. Example: When the setupapp URI is `/setupapp/hama/asp/BrowseXML/loginXML.asp` you have to set `hama` here).
 	- There are to ways to store, which episodes of a podcasts were already played (new ones are marked by `*`)
 		- Use the Redis-Data-Volume (Redis will load its dump files on container startup)
 		- Create a CronJob to `/cron.php` (this will dump the already played episodes to a JSON-File and load the file on container startup)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
       - CONF_OWN_STREAM_URL=http://172.21.0.1:8081/?k=
       - CONF_PROXY_OWN_STREAM=false
       - CONF_SHUFFLE_MUSIC=true
-      - CONF_SETUPAPP_INDENT=hama
+      - CONF_SETUPAPP_IDENT=hama
     depends_on:
       - redis
   redis:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,6 +26,7 @@ services:
       - CONF_OWN_STREAM_URL=http://172.21.0.1:8081/?k=
       - CONF_PROXY_OWN_STREAM=false
       - CONF_SHUFFLE_MUSIC=true
+      - CONF_SETUPAPP_INDENT=hama
     depends_on:
       - redis
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - CONF_OWN_STREAM_URL=http://stream.example.com/?key= # url prefix to open own streamS, key are appended
       - CONF_PROXY_OWN_STREAM=false # use the proxy for the own streams (all own streams are proxied by the docker image)
       - CONF_SHUFFLE_MUSIC=true # random shuffle music in nextcloud radio stations
+      - CONF_SETUPAPP_INDENT=hama # ident string for setupapp uri
     depends_on:
       - redis
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - CONF_OWN_STREAM_URL=http://stream.example.com/?key= # url prefix to open own streamS, key are appended
       - CONF_PROXY_OWN_STREAM=false # use the proxy for the own streams (all own streams are proxied by the docker image)
       - CONF_SHUFFLE_MUSIC=true # random shuffle music in nextcloud radio stations
-      - CONF_SETUPAPP_INDENT=hama # ident string for setupapp uri
+      - CONF_SETUPAPP_IDENT=hama # ident string for setupapp uri
     depends_on:
       - redis
   redis:

--- a/php/classes/Config.php
+++ b/php/classes/Config.php
@@ -19,6 +19,7 @@ define( 'ENV_CACHE_EXPIRE', intval($_ENV['CONF_CACHE_EXPIRE']));
 define( 'ENV_OWN_STREAM', $_ENV['CONF_OWN_STREAM'] == 'true');
 define( 'ENV_PROXY_OWN_STREAM', $_ENV['CONF_PROXY_OWN_STREAM'] == 'true');
 define( 'ENV_SHUFFLE_MUSIC', $_ENV['CONF_SHUFFLE_MUSIC'] == 'true');
+define( 'ENV_SETUPAPP_IDENT', $_ENV['CONF_SETUPAPP_INDENT'] );
 
 // IP on reverse proxy setup
 if( !empty($_SERVER['HTTP_X_REAL_IP']) ){
@@ -55,6 +56,11 @@ class Config {
 	 * Random shuffle music station streams from nc
 	 */
 	CONST SHUFFLE_MUSIC = ENV_SHUFFLE_MUSIC;
+
+	/**
+	 * Ident string for setupapp uri
+	 */
+	CONST SETUPAPP_IDENT = ENV_SETUPAPP_IDENT;
 
 	/**
 	 * Store redis cache for ALLOWED_DOMAINS, OWN_STREAM

--- a/php/classes/Config.php
+++ b/php/classes/Config.php
@@ -19,7 +19,7 @@ define( 'ENV_CACHE_EXPIRE', intval($_ENV['CONF_CACHE_EXPIRE']));
 define( 'ENV_OWN_STREAM', $_ENV['CONF_OWN_STREAM'] == 'true');
 define( 'ENV_PROXY_OWN_STREAM', $_ENV['CONF_PROXY_OWN_STREAM'] == 'true');
 define( 'ENV_SHUFFLE_MUSIC', $_ENV['CONF_SHUFFLE_MUSIC'] == 'true');
-define( 'ENV_SETUPAPP_IDENT', $_ENV['CONF_SETUPAPP_INDENT'] );
+define( 'ENV_SETUPAPP_IDENT', $_ENV['CONF_SETUPAPP_IDENT'] );
 
 // IP on reverse proxy setup
 if( !empty($_SERVER['HTTP_X_REAL_IP']) ){

--- a/php/index.php
+++ b/php/index.php
@@ -22,7 +22,7 @@ require_once( __DIR__ . '/classes/autoload.php' );
  */
 $uri = !empty( $_GET['uri'] ) && is_string($_GET['uri']) ? $_GET['uri'] : 'none';
 // Login (Radio tries a login before accessing the api)
-if( $uri == '/setupapp/hama/asp/BrowseXML/loginXML.asp' && !isset( $_GET['mac'] ) ){
+if( $uri == '/setupapp/' . Config::SETUPAPP_IDENT . '/asp/BrowseXML/loginXML.asp' && !isset( $_GET['mac'] ) ){
 	Output::sendAnswer('<EncryptedToken>3a3f5ac48a1dab4e</EncryptedToken>');
 	die(); //will never be reached
 }


### PR DESCRIPTION
Hi.
I figured out that the ident in the setupapp URI varies per manufacturer.

My internet radio calls the URI `/setupapp/aldi/asp/BrowseXML/loginXML.asp` whereas your radio seems to use `/setupapp/hama/asp/BrowseXML/loginXML.asp`.

Because of this I made this ident string configurable via environment variable and set the default in the docker-compose file to `hama`.